### PR TITLE
Align branch: add strategy and remote options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ A collection of git commands to help managing mutliple git repositories at once.
 For each repository in the given directory, it will align the target branch to the given source branch.
 
 ```bash
-swit align-branch -source <source-branch> -target <target-branch> -directory <directory>
+swit align-branch -source <source-branch> -target <target-branch> [-directory <directory>] [-strategy <pull|merge>] [-remote <remote_name>]
 ```
+*Default strategy: merge*
+*Default remote:   origin*
 
 ## Find Branch
 

--- a/commands/align_branch.go
+++ b/commands/align_branch.go
@@ -16,6 +16,8 @@ type AlignBranchCommand struct {
 	source    *string
 	target    *string
 	directory *string
+	strategy  *string
+	remote    *string
 }
 
 func (c *AlignBranchCommand) GetFriendlyName() string {
@@ -36,9 +38,20 @@ func (c *AlignBranchCommand) CheckFlagsAndDefaults() error {
 	if c.source == nil || len(*c.source) == 0 {
 		return fmt.Errorf("missing required source branch")
 	}
+	if *c.strategy != git.MERGE_STRATEGY && *c.strategy != git.PULL_STRATEGY {
+		return fmt.Errorf("strategy '%s' is not valid. Valid values are: 'merge' (default) | 'pull'", *c.strategy)
+	}
 	if c.directory == nil {
 		dir := "."
 		c.directory = &dir
+	}
+	if c.remote == nil {
+		defaultRemote := "origin"
+		c.remote = &defaultRemote
+	}
+	if c.strategy == nil {
+		strategy := git.MERGE_STRATEGY
+		c.strategy = &strategy
 	}
 
 	return nil
@@ -56,7 +69,7 @@ func (c *AlignBranchCommand) Execute(ctx context.Context) error {
 
 	pool.Execute(
 		func(path string) error {
-			if err := git.Align(context.Background(), path, *c.source, *c.target); err != nil {
+			if err := git.Align(context.Background(), path, *c.source, *c.target, *c.strategy, *c.remote); err != nil {
 				log.Printf("Failed to align branch in %s: %s\n", path, err.Error())
 				return err
 			}

--- a/commands/align_branch.go
+++ b/commands/align_branch.go
@@ -38,7 +38,7 @@ func (c *AlignBranchCommand) CheckFlagsAndDefaults() error {
 	if c.source == nil || len(*c.source) == 0 {
 		return fmt.Errorf("missing required source branch")
 	}
-	if *c.strategy != git.MERGE_STRATEGY && *c.strategy != git.PULL_STRATEGY {
+	if c.strategy != nil && *c.strategy != git.MERGE_STRATEGY && *c.strategy != git.PULL_STRATEGY {
 		return fmt.Errorf("strategy '%s' is not valid. Valid values are: 'merge' (default) | 'pull'", *c.strategy)
 	}
 	if c.directory == nil {

--- a/internal/git/execute.go
+++ b/internal/git/execute.go
@@ -1,0 +1,19 @@
+package git
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func Execute(path string, commands ...string) error {
+	cmd := exec.Command("git", commands...)
+	cmd.Dir = path
+	cmd.Env = os.Environ()
+
+	if err := cmd.Run(); err != nil {
+		firstCommand := commands[0]
+		return fmt.Errorf("failed to %s: %s", firstCommand, err.Error())
+	}
+	return nil
+}

--- a/internal/git/pull.go
+++ b/internal/git/pull.go
@@ -3,24 +3,31 @@ package git
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
 
 	"it.smaso/git_swiss/internal/utilities"
 )
 
-func Pull(ctx context.Context, path string) error {
+// If the provided path is not a git repository
+// an error will be returned.
+func CheckGitRepo(path string) error {
 	if !utilities.ContainsFile(path, ".git") {
 		return fmt.Errorf("not executing in a git repository")
 	}
-
-	cmd := exec.Command("git", "pull")
-	cmd.Dir = path
-	cmd.Env = os.Environ()
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to pull: %s", err.Error())
-	}
-
 	return nil
+}
+
+func Pull(ctx context.Context, path string) error {
+	err := CheckGitRepo(path)
+	if err == nil {
+		return Execute(path, "pull")
+	}
+	return err
+}
+
+func MergePull(ctx context.Context, path string, remote string, source string) error {
+	err := CheckGitRepo(path)
+	if err == nil {
+		return Execute(path, "pull", remote, source)
+	}
+	return err
 }


### PR DESCRIPTION
- Creato file execute (package git) per una funzione di esecuzione comandi git comune, con gestione comune errori
- Estratta logica di check del git repository in funzione a parte
- Aggiornato Pull usando Execute
- Aggiunto metodo MergePull al pull.go (usando Execute e metodo comune di Check Repository)
- Prevista opzione strategy (default: merge ; errore se presente ma diversa da 'merge' o 'pull')
- Prevista opzione remote (per il nome del remoto che serve in "git pull <remote> <source>"; Default "origin")

Aggiornato README di conseguenza.


**ASSOLUTAMENTE NON TESTATA NEANCHE PER SBAGLIO, SUL CAMPO**